### PR TITLE
Leverage ConsumerTags in cost allocation CSV files to ease Provider Services' life

### DIFF
--- a/cloud_cost_allocation/cost_items.py
+++ b/cloud_cost_allocation/cost_items.py
@@ -43,33 +43,6 @@ class CostItem(ABC):
         self.currency = ""
         self.nb_matching_provider_tag_selectors = 0
 
-    def fill_from_tags(self, config: ConfigParser) -> None:
-
-        # Service
-        for service_tag_key in config['TagKey']['Service'].split(","):
-            service_tag_key = service_tag_key.strip()
-            if service_tag_key in self.tags:
-                self.service = self.tags[service_tag_key].strip().lower()
-                break
-
-        # Instance
-        if 'Instance' in config['TagKey']:
-            for instance_tag_key in config['TagKey']['Instance'].split(","):
-                instance_tag_key = instance_tag_key.strip()
-                if instance_tag_key in self.tags:
-                    self.instance = self.tags[instance_tag_key].strip().lower()
-                    break
-
-        # Dimensions
-        if 'Dimensions' in config['General']:
-            for dimension in config['General']['Dimensions'].split(","):
-                dimension = dimension.strip()
-                for dimension_tag_key in config['TagKey'][dimension].split(","):
-                    dimension_tag_key = dimension_tag_key.strip()
-                    if dimension_tag_key in self.tags:
-                        self.dimensions[dimension] = self.tags[dimension_tag_key].strip().lower()
-                        break
-
     def get_consumer_cost_item_provider_service_instance(self) -> 'ServiceInstance':
         # Default behavior, overridden in child classes
         return None
@@ -150,19 +123,6 @@ class CloudCostItem(CostItem):
         self.cloud_amortized_cost = 0.0
         self.cloud_on_demand_cost = 0.0
         self.currency = ""
-
-    def fill_from_tags(self, config: ConfigParser) -> None:
-
-        # Call parent method
-        super().fill_from_tags(config)
-
-        # Default service
-        if not self.service:
-            self.service = config['General']['DefaultService'].strip()
-
-        # Default instance
-        if not self.instance:
-            self.instance = self.service
 
     def matches_cloud_tag_selector(self, cloud_tag_selector: str, provider_service: str) -> bool:
         eval_globals_dict = {}

--- a/cloud_cost_allocation/cost_items.py
+++ b/cloud_cost_allocation/cost_items.py
@@ -43,6 +43,33 @@ class CostItem(ABC):
         self.currency = ""
         self.nb_matching_provider_tag_selectors = 0
 
+    def fill_from_tags(self, config: ConfigParser) -> None:
+
+        # Service
+        for service_tag_key in config['TagKey']['Service'].split(","):
+            service_tag_key = service_tag_key.strip()
+            if service_tag_key in self.tags:
+                self.service = self.tags[service_tag_key].strip().lower()
+                break
+
+        # Instance
+        if 'Instance' in config['TagKey']:
+            for instance_tag_key in config['TagKey']['Instance'].split(","):
+                instance_tag_key = instance_tag_key.strip()
+                if instance_tag_key in self.tags:
+                    self.instance = self.tags[instance_tag_key].strip().lower()
+                    break
+
+        # Dimensions
+        if 'Dimensions' in config['General']:
+            for dimension in config['General']['Dimensions'].split(","):
+                dimension = dimension.strip()
+                for dimension_tag_key in config['TagKey'][dimension].split(","):
+                    dimension_tag_key = dimension_tag_key.strip()
+                    if dimension_tag_key in self.tags:
+                        self.dimensions[dimension] = self.tags[dimension_tag_key].strip().lower()
+                        break
+
     def get_consumer_cost_item_provider_service_instance(self) -> 'ServiceInstance':
         # Default behavior, overridden in child classes
         return None
@@ -124,6 +151,19 @@ class CloudCostItem(CostItem):
         self.cloud_on_demand_cost = 0.0
         self.currency = ""
 
+    def fill_from_tags(self, config: ConfigParser) -> None:
+
+        # Call parent method
+        super().fill_from_tags(config)
+
+        # Default service
+        if not self.service:
+            self.service = config['General']['DefaultService'].strip()
+
+        # Default instance
+        if not self.instance:
+            self.instance = self.service
+
     def matches_cloud_tag_selector(self, cloud_tag_selector: str, provider_service: str) -> bool:
         eval_globals_dict = {}
         for key, value in self.tags.items():
@@ -143,37 +183,6 @@ class CloudCostItem(CostItem):
                   provider_service +
                   "'")
         return match
-
-    def fill_from_tags(self, config: ConfigParser) -> None:
-
-        # Service
-        for service_tag_key in config['TagKey']['Service'].split(","):
-            service_tag_key = service_tag_key.strip()
-            if service_tag_key in self.tags:
-                self.service = self.tags[service_tag_key].strip().lower()
-                break
-        if not self.service:
-            self.service = config['General']['DefaultService'].strip()
-
-        # Instance
-        if 'Instance' in config['TagKey']:
-            for instance_tag_key in config['TagKey']['Instance'].split(","):
-                instance_tag_key = instance_tag_key.strip()
-                if instance_tag_key in self.tags:
-                    self.instance = self.tags[instance_tag_key].strip().lower()
-                    break
-        if not self.instance:  # Default value: same as service
-            self.instance = self.service
-
-        # Dimensions
-        if 'Dimensions' in config['General']:
-            for dimension in config['General']['Dimensions'].split(","):
-                dimension = dimension.strip()
-                for dimension_tag_key in config['TagKey'][dimension].split(","):
-                    dimension_tag_key = dimension_tag_key.strip()
-                    if dimension_tag_key in self.tags:
-                        self.dimensions[dimension] = self.tags[dimension_tag_key].strip().lower()
-                        break
 
     def visit_for_allocation(self,
                              visited_service_instance_list: list['ServiceInstance'],

--- a/cloud_cost_allocation/reader/azure_ea_amortized_cost_reader.py
+++ b/cloud_cost_allocation/reader/azure_ea_amortized_cost_reader.py
@@ -73,7 +73,12 @@ class AzureEaAmortizedCostReader(GenericReader):
 
         else:
             # Fill cost item from tags
-            cloud_cost_item.fill_from_tags(self.config)
+            self.fill_from_tags(cloud_cost_item)
+            # Set default values for service + instance if needed
+            if not cloud_cost_item.service:
+                cloud_cost_item.service = self.config['General']['DefaultService'].strip()
+            if not cloud_cost_item.instance:
+                # Set the default value
+                cloud_cost_item.instance = cloud_cost_item.service
 
         return cloud_cost_item
-

--- a/cloud_cost_allocation/reader/base_reader.py
+++ b/cloud_cost_allocation/reader/base_reader.py
@@ -28,6 +28,32 @@ class GenericReader(ABC):
                 # Add cloud cost item
                 cost_items.append(cost_item)
 
+    def fill_from_tags(self, cost_item) -> None:
+        # Service
+        for service_tag_key in self.config['TagKey']['Service'].split(","):
+            service_tag_key = service_tag_key.strip()
+            if service_tag_key in cost_item.tags:
+                cost_item.service = cost_item.tags[service_tag_key].strip().lower()
+                break
+
+        # Instance
+        if 'Instance' in self.config['TagKey']:
+            for instance_tag_key in self.config['TagKey']['Instance'].split(","):
+                instance_tag_key = instance_tag_key.strip()
+                if instance_tag_key in cost_item.tags:
+                    cost_item.instance = cost_item.tags[instance_tag_key].strip().lower()
+                    break
+
+        # Dimensions
+        if 'Dimensions' in self.config['General']:
+            for dimension in self.config['General']['Dimensions'].split(","):
+                dimension = dimension.strip()
+                for dimension_tag_key in self.config['TagKey'][dimension].split(","):
+                    dimension_tag_key = dimension_tag_key.strip()
+                    if dimension_tag_key in cost_item.tags:
+                        cost_item.dimensions[dimension] = cost_item.tags[dimension_tag_key].strip().lower()
+                        break
+
     @abstractmethod
     def read_item(self, item) -> CostItem:
         pass

--- a/cloud_cost_allocation/reader/csv_cost_allocation_keys_reader.py
+++ b/cloud_cost_allocation/reader/csv_cost_allocation_keys_reader.py
@@ -122,9 +122,9 @@ class CSV_CostAllocationKeysReader(GenericReader):
         # Note: if both consumer tags and other consumer columns (ConsumerService, ConsumerInstance,
         # Consumer<Dimensions>) are populated with overlapping info, then info from other consumer columns takes
         # precedence over info from consumer tags (other consumer columns will be processed after consumer tags)
-        consumer_cost_item.fill_from_tags(self.config)
+        self.fill_from_tags(consumer_cost_item)
 
-        # Populate consumer cost item info from other consumer columns
+        # Populate/overwrite consumer cost item info from explicit consumer columns if set
         if 'ConsumerService' in line and line['ConsumerService']:
             consumer_cost_item.service = line['ConsumerService'].lower()
         if 'ConsumerInstance' in line and line['ConsumerInstance']:

--- a/cloud_cost_allocation/reader/csv_cost_allocation_keys_reader.py
+++ b/cloud_cost_allocation/reader/csv_cost_allocation_keys_reader.py
@@ -21,7 +21,6 @@ class CSV_CostAllocationKeysReader(GenericReader):
         'nb_provider_meters',  # type: int
     )
 
-
     def __init__(self, cost_item_factory: CostItemFactory, config: ConfigParser):
         '''
         Constructor
@@ -36,7 +35,7 @@ class CSV_CostAllocationKeysReader(GenericReader):
         # Create item
         consumer_cost_item = self.cost_item_factory.create_consumer_cost_item()
 
-        # Populate item
+        # Populate provider service amd instance info
         consumer_cost_item.date_str = line['Date'].strip()
         if 'ProviderService' in line:
             consumer_cost_item.provider_service = line['ProviderService'].lower()
@@ -47,76 +46,6 @@ class CSV_CostAllocationKeysReader(GenericReader):
             consumer_cost_item.provider_instance = line['ProviderInstance'].lower()
         if not consumer_cost_item.provider_instance:
             consumer_cost_item.provider_instance = consumer_cost_item.provider_service  # Default value
-        if 'Product' in line:
-            consumer_cost_item.product = line['Product'].lower()
-        if 'ProductMeterName' in line:
-            consumer_cost_item.product_meter_name = line['ProductMeterName']
-        if 'ProductMeterUnit' in line:
-            consumer_cost_item.product_meter_unit = line['ProductMeterUnit']
-        if 'ProductMeterValue' in line:
-            consumer_cost_item.product_meter_value = line['ProductMeterValue']
-        if 'ConsumerService' in line:
-            consumer_cost_item.service = line['ConsumerService'].lower()
-        if 'ConsumerInstance' in line:
-            consumer_cost_item.instance = line['ConsumerInstance'].lower()
-        # Set default values for service and instance
-        if not consumer_cost_item.service:
-            if consumer_cost_item.product:  # Set self-consumption, to materialize final consumption
-                consumer_cost_item.service = consumer_cost_item.provider_service
-                consumer_cost_item.instance = consumer_cost_item.provider_instance
-            else:  # Garbage collector
-                consumer_cost_item.service = self.config['General']['DefaultService'].strip()
-                consumer_cost_item.instance = consumer_cost_item.service
-        elif not consumer_cost_item.instance:  # Same as service by default
-            consumer_cost_item.instance = consumer_cost_item.service
-        if 'Dimensions' in self.config['General']:
-            for dimension in self.config['General']['Dimensions'].split(','):
-                consumer_dimension = 'Consumer' + dimension.strip()
-                if consumer_dimension in line:
-                    consumer_cost_item.dimensions[dimension] = line[consumer_dimension].lower()
-        if 'ConsumerTags' in line:
-            consumer_tags = line["ConsumerTags"]
-            if consumer_tags:
-                tags = consumer_tags.split(',')
-                for tag in tags:
-                    if tag:
-                        key_value_match = re.match("([^:]+):([^:]*)", tag)
-                        if key_value_match:
-                            key = key_value_match.group(1).strip().lower()
-                            value = key_value_match.group(2).strip().lower()
-                            consumer_cost_item.tags[key] = value
-                        else:
-                            error("Unexpected consumer tag format: '" + tag + "'")
-        if self.nb_provider_meters:
-            for i in range(1, self.nb_provider_meters + 1):
-                provider_meter_name = None
-                provider_meter_unit = None
-                provider_meter_value = None
-                if 'ProviderMeterName%d' % i in line:
-                    provider_meter_name = line['ProviderMeterName%d' % i]
-                #consumer_cost_item.provider_meter_names.append(provider_meter_name)
-                if 'ProviderMeterUnit%d' % i in line:
-                    provider_meter_unit = line['ProviderMeterUnit%d' % i]
-                #consumer_cost_item.provider_meter_units.append(provider_meter_unit)
-                if 'ProviderMeterValue%d' % i in line:
-                    provider_meter_value_column = 'ProviderMeterValue%d' % i
-                    provider_meter_value = line[provider_meter_value_column]
-                    if provider_meter_value:
-                        try:
-                            float(provider_meter_value)
-                        except (TypeError, ValueError):
-                            error("Value '" + provider_meter_value + "' of '" + provider_meter_value_column +
-                                  "' of ProviderService '" + consumer_cost_item.provider_service + "'" +
-                                  "is not a float")
-                            provider_meter_value = None
-                #consumer_cost_item.provider_meter_values.append(provider_meter_value)
-                if provider_meter_name or provider_meter_unit or provider_meter_value:
-                    meter = {}
-                    meter['Name'] = provider_meter_name
-                    meter['Unit'] = provider_meter_unit
-                    meter['Value'] = provider_meter_value
-                    consumer_cost_item.provider_meters.append(meter)
-
         consumer_cost_item.provider_cost_allocation_type = "Key"  # Default value
         if 'ProviderCostAllocationType' in line:
             consumer_cost_item.provider_cost_allocation_type = line['ProviderCostAllocationType']
@@ -124,6 +53,10 @@ class CSV_CostAllocationKeysReader(GenericReader):
                 error("Unknown ProviderCostAllocationType '" + consumer_cost_item.provider_cost_allocation_type +
                       "' for ProviderService '" + consumer_cost_item.provider_service + "'")
                 return None
+
+        # Populate provider tag selector and cost allocation type
+        if "ProviderTagSelector" in line:
+            consumer_cost_item.provider_tag_selector = line["ProviderTagSelector"].lower()
         if consumer_cost_item.provider_cost_allocation_type == 'Key':
             key_str = ""
             if 'ProviderCostAllocationKey' in line and line['ProviderCostAllocationKey']:
@@ -141,7 +74,86 @@ class CSV_CostAllocationKeysReader(GenericReader):
             if 'ProviderCostAllocationCloudTagSelector' in line:
                 consumer_cost_item.provider_cost_allocation_cloud_tag_selector = \
                     line['ProviderCostAllocationCloudTagSelector']
-        if "ProviderTagSelector" in line:
-            consumer_cost_item.provider_tag_selector = line["ProviderTagSelector"].lower()
+
+        # Populate provider meters
+        if self.nb_provider_meters:
+            for i in range(1, self.nb_provider_meters + 1):
+                provider_meter_name = None
+                provider_meter_unit = None
+                provider_meter_value = None
+                if 'ProviderMeterName%d' % i in line:
+                    provider_meter_name = line['ProviderMeterName%d' % i]
+                if 'ProviderMeterUnit%d' % i in line:
+                    provider_meter_unit = line['ProviderMeterUnit%d' % i]
+                if 'ProviderMeterValue%d' % i in line:
+                    provider_meter_value_column = 'ProviderMeterValue%d' % i
+                    provider_meter_value = line[provider_meter_value_column]
+                    if provider_meter_value:
+                        try:
+                            float(provider_meter_value)
+                        except (TypeError, ValueError):
+                            error("Value '" + provider_meter_value + "' of '" + provider_meter_value_column +
+                                  "' of ProviderService '" + consumer_cost_item.provider_service + "'" +
+                                  "is not a float")
+                            provider_meter_value = None
+                if provider_meter_name or provider_meter_unit or provider_meter_value:
+                    meter = {}
+                    meter['Name'] = provider_meter_name
+                    meter['Unit'] = provider_meter_unit
+                    meter['Value'] = provider_meter_value
+                    consumer_cost_item.provider_meters.append(meter)
+
+        # Populate tags from consumer tags
+        if 'ConsumerTags' in line:
+            consumer_tags = line["ConsumerTags"]
+            if consumer_tags:
+                tags = consumer_tags.split(',')
+                for tag in tags:
+                    if tag:
+                        key_value_match = re.match("([^:]+):([^:]*)", tag)
+                        if key_value_match:
+                            key = key_value_match.group(1).strip().lower()
+                            value = key_value_match.group(2).strip().lower()
+                            consumer_cost_item.tags[key] = value
+                        else:
+                            error("Unexpected consumer tag format: '" + tag + "'")
+
+        # Populate consumer cost item info from consumer tags
+        # Note: if both consumer tags and other consumer columns (ConsumerService, ConsumerInstance,
+        # Consumer<Dimensions>) are populated with overlapping info, then info from other consumer columns takes
+        # precedence over info from consumer tags (other consumer columns will be processed after consumer tags)
+        consumer_cost_item.fill_from_tags(self.config)
+
+        # Populate consumer cost item info from other consumer columns
+        if 'ConsumerService' in line and line['ConsumerService']:
+            consumer_cost_item.service = line['ConsumerService'].lower()
+        if 'ConsumerInstance' in line and line['ConsumerInstance']:
+            consumer_cost_item.instance = line['ConsumerInstance'].lower()
+        if 'Dimensions' in self.config['General']:
+            for dimension in self.config['General']['Dimensions'].split(','):
+                consumer_dimension = 'Consumer' + dimension.strip()
+                if consumer_dimension in line and line[consumer_dimension]:
+                    consumer_cost_item.dimensions[dimension] = line[consumer_dimension].lower()
+
+        # Populate product info
+        if 'Product' in line:
+            consumer_cost_item.product = line['Product'].lower()
+        if 'ProductMeterName' in line:
+            consumer_cost_item.product_meter_name = line['ProductMeterName']
+        if 'ProductMeterUnit' in line:
+            consumer_cost_item.product_meter_unit = line['ProductMeterUnit']
+        if 'ProductMeterValue' in line:
+            consumer_cost_item.product_meter_value = line['ProductMeterValue']
+
+        # Set default values for service and instance
+        if not consumer_cost_item.service:
+            if consumer_cost_item.product:  # Set self-consumption, to materialize final consumption
+                consumer_cost_item.service = consumer_cost_item.provider_service
+                consumer_cost_item.instance = consumer_cost_item.provider_instance
+            else:  # Consumer is default service
+                consumer_cost_item.service = self.config['General']['DefaultService'].strip()
+                consumer_cost_item.instance = consumer_cost_item.service
+        elif not consumer_cost_item.instance:  # Same as service by default
+            consumer_cost_item.instance = consumer_cost_item.service
 
         return consumer_cost_item

--- a/tests/test1/test1_allocated_cost.csv
+++ b/tests/test1/test1_allocated_cost.csv
@@ -6,7 +6,7 @@ Date,Service,Instance,Tags,AmortizedCost,OnDemandCost,Currency,ProviderService,P
 2022-03-09,history,history,,1.0,1.0,EUR,monitoring,monitoring,,Key,10.0,,,,,,,,,,time-series,ts,10,,,,,N
 2022-03-09,monitoring,monitoring,,5.0,5.0,EUR,container,container,"'cloud_resource_id' in globals() and __import__('re').match('/az/virtualmachines/.*',cloud_resource_id)",Key,0.25,,,,,,,,grafana,,cpu,core,0.25,memory,gb,0.5,,N
 2022-03-09,monitoring,monitoring,,2.0,2.0,EUR,container,container,"'cloud_resource_id' in globals() and __import__('re').match('/az/disks/.*',cloud_resource_id)",Key,1.0,,,,,,,,prometheus,,disk,gb,1,,,,,N
-2022-03-09,reporting,reporting,"cost_center:5678,",10.0,10.0,EUR,container,container,"'cloud_resource_id' in globals() and __import__('re').match('/az/virtualmachines/.*',cloud_resource_id)",Key,0.5,,,,,,,,batch,prd,cpu,core,0.5,memory,gb,1,,N
+2022-03-09,reporting,reporting,"service:reporting,component:batch,environment:prd,cost_center:5678,",10.0,10.0,EUR,container,container,"'cloud_resource_id' in globals() and __import__('re').match('/az/virtualmachines/.*',cloud_resource_id)",Key,0.5,,,,,,,,batch,prd,cpu,core,0.5,memory,gb,1,,N
 2022-03-09,reporting,reporting,,1.0,1.0,EUR,monitoring,monitoring,,Key,10.0,,,,,,,,,,time-series,ts,10,,,,,N
 2022-03-09,reporting,reporting,,12.0,12.0,EUR,history,history,,Key,1.0,,,,,,,,,,records,rec,500,,,,,N
 2022-03-09,reporting,reporting,,20.7,20.7,EUR,reporting,reporting,,Key,9.0,,b2b,20.7,20.7,Monthly Active Users,usr,100,,,reports,rep,9,,,,,Y

--- a/tests/test1/test1_cost_allocation_keys.csv
+++ b/tests/test1/test1_cost_allocation_keys.csv
@@ -1,6 +1,6 @@
 Date,ProviderService,ProviderTagSelector,ProviderMeterName1,ProviderMeterValue1,ProviderMeterUnit1,ProviderMeterName2,ProviderMeterValue2,ProviderMeterUnit2,ProviderCostAllocationKey,ConsumerService,ConsumerComponent,ConsumerEnvironment,ConsumerTags,Product,ProductMeterName,ProductMeterValue,ProductMeterUnit
 2022-03-09,container,"'cloud_resource_id' in globals() and __import__('re').match('/az/virtualmachines/.*',cloud_resource_id)",cpu,3,core,memory,6,gb,3,web,apache,prd,cost_center:1234,,,,
-2022-03-09,container,"'cloud_resource_id' in globals() and __import__('re').match('/az/virtualmachines/.*',cloud_resource_id)",cpu,0.5,core,memory,1,gb,0.5,reporting,batch,prd,cost_center:5678,,,,
+2022-03-09,container,"'cloud_resource_id' in globals() and __import__('re').match('/az/virtualmachines/.*',cloud_resource_id)",cpu,0.5,core,memory,1,gb,0.5,,,,"service:reporting,component:batch,environment:prd,cost_center:5678",,,,
 2022-03-09,container,"'cloud_resource_id' in globals() and __import__('re').match('/az/virtualmachines/.*',cloud_resource_id)",cpu,0.25,core,memory,0.5,gb,0.25,history,,,,,,,
 2022-03-09,container,"'cloud_resource_id' in globals() and __import__('re').match('/az/virtualmachines/.*',cloud_resource_id)",cpu,0.25,core,memory,0.5,gb,0.25,monitoring,grafana,,,,,,
 2022-03-09,container,"'cloud_resource_id' in globals() and __import__('re').match('/az/disks/.*',cloud_resource_id)",disk,9,gb,,,,9,history,,,,,,,


### PR DESCRIPTION
Populate Service, Instance and Dimensions for ConsumerCostItem from ConsumerTags, in order to ease the generation of cost allocation CSV files for Provider Services (they just need to propagate the tags given by their Consumer Services)